### PR TITLE
chore(ci): mise à jour des dépendances

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -10,8 +10,32 @@ on:
 env:
   IMAGE_PREFIX: ouestfrance/cdp2
 jobs:
-  build:
+  build: 
+    runs-on: ubuntu-latest
     name: Build
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.7.5'
+    - uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools mock wheel
+        python -m pip install -r requirements.txt
+        python3 setup.py install
+    - name: Unit tests
+      run: |
+        python setup.py test
+  push-tag:
+    name: Push tag
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -34,20 +58,7 @@ jobs:
           if [[ "${{github.event_name}}" == "push" && "${{github.ref}}" == "refs/heads/master" ]]; then
              TAG=$TAG,$IMAGE_PREFIX:latest 
           fi
-          echo ::set-output name=TAGS::$TAG       
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: '3.7.5'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install setuptools  mock
-          python -m pip install -r requirements.txt
-          python3 setup.py install
-      - name: Unit tests
-        run: |
-          python setup.py test          
+          echo ::set-output name=TAGS::$TAG        
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM gcr.io/kaniko-project/executor:latest AS kaniko
-FROM openpolicyagent/conftest:v0.25.0 AS conftest
-FROM alpine:3.13.5
+FROM openpolicyagent/conftest:v0.27.0 AS conftest
+FROM alpine:3.14.1
 
 ARG VERSION_HADOLINT="v2.4.1"
 ARG VERSION_KUBECTL="v1.21.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 docopt==0.6.2
-pyjq==2.4.0
-python-gitlab==1.11.0
-ruamel.yaml==0.16.5
+pyjq==2.5.2
+python-gitlab==2.10.0
+ruamel.yaml==0.17.11
 verboselogs==1.7
 envsubst==0.1.5


### PR DESCRIPTION
Bonjour,
J'ai mis à jour les dépendances actuelles via dependabot.
Comme je n'ai pas d'identifiants sur le hub docker, j'ai séparé le step des tests pythons et celui du push sur le hub docker.
J'ai aussi ajouté une mise en cache des dépendances python